### PR TITLE
refactor(fiori apps): Change to EventBus for navigation

### DIFF
--- a/app/templates/fiori_application/_Component.js
+++ b/app/templates/fiori_application/_Component.js
@@ -13,7 +13,6 @@ Component details:
 	sap.ui.core.UIComponent.extend("<%= fioriComponentNamespace %>.Component", {
 
 		createContent: function() {
-
 			// create root view
 			var oView = sap.ui.view({
 				id: "idViewRoot",
@@ -36,9 +35,7 @@ Component details:
 			deviceModel.setDefaultBindingMode("OneWay");
 			oView.setModel(deviceModel, "device");
 
-			// done
 			return oView;
-
 		}
 	});
 

--- a/app/templates/fiori_application/view/_Detail.controller.js
+++ b/app/templates/fiori_application/view/_Detail.controller.js
@@ -7,12 +7,24 @@
 
 	sap.ui.controller("<%= fioriComponentNamespace %>.view.Detail", {
 
-		handleNavButtonPress: function() {
-			this.navigation.navBack();
+		onInit: function() {
+			this.bus = sap.ui.getCore().getEventBus();
 		},
 
-		handleApprove: function() {
+		handleNavButtonPress: function() {
+			this.bus.publish("nav", "back");
+		},
 
+		handleLineItemPress: function(evt) {
+			this.bus.publish("nav", "to", {
+				id: "idViewRoot--idViewLineItem",
+				data: {
+					context: evt.getSource().getBindingContext()
+				}
+			});
+		},
+		
+		handleApprove: function() {
 			// show confirmation dialog
 			var bundle = this.getView().getModel("i18n").getResourceBundle();
 			sap.m.MessageBox.confirm(
@@ -28,11 +40,8 @@
 
 				bundle.getText("ApproveDialogTitle")
 			);
-		},
-
-		handleLineItemPress: function(evt) {
-			this.navigation.navTo("idViewRoot--idViewLineItem", evt.getSource().getBindingContext());
 		}
+
 	});
 
 }());

--- a/app/templates/fiori_application/view/_LineItem.controller.js
+++ b/app/templates/fiori_application/view/_LineItem.controller.js
@@ -3,8 +3,12 @@
 
 	sap.ui.controller("<%= fioriComponentNamespace %>.view.LineItem", {
 
+		onInit: function() {
+			this.bus = sap.ui.getCore().getEventBus();
+		},
+
 		handleNavBack: function() {
-			this.navigation.navBack();
+			this.bus.publish("nav", "back");
 		}
 
 	});

--- a/app/templates/fiori_application/view/_Master.controller.js
+++ b/app/templates/fiori_application/view/_Master.controller.js
@@ -6,6 +6,10 @@
 
 	sap.ui.controller("<%= fioriComponentNamespace %>.view.Master", {
 
+		onInit: function() {
+			this.bus = sap.ui.getCore().getEventBus();
+		},
+
 		onExit: function() {
 			if (this._lineItemViewDialog) {
 				this._lineItemViewDialog.destroy();
@@ -13,13 +17,16 @@
 			}
 		},
 
-		handleListItemPress: function(evt) {
-			var context = evt.getSource().getBindingContext();
-			this.nav.to("Detail", context);
+		handleListSelect: function(evt) {
+			this.bus.publish("nav", "to", {
+				id: "idViewRoot--idViewDetail",
+				data: {
+					context: evt.getParameter("listItem").getBindingContext()
+				}
+			});
 		},
 
 		handleSearch: function(evt) {
-
 			// create model filter
 			var filters = [];
 			var query = evt.getParameter("query");
@@ -34,13 +41,8 @@
 			binding.filter(filters);
 		},
 
-		handleListSelect: function(evt) {
-			this.navigation.navTo("idViewRoot--idViewDetail", evt.getParameter("listItem").getBindingContext());
-		},
-
 		handleViewSettings: function() {
-
-			// create dialog
+			// create and open settings dialog
 			var that = this;
 			if (!this._lineItemViewDialog) {
 				this._lineItemViewDialog = new sap.m.ViewSettingsDialog({
@@ -60,7 +62,7 @@
 						if (mParams.groupItem) {
 							var sPath = mParams.groupItem.getKey();
 							var bDescending = mParams.groupDescending;
-							var vGroup = <%= fioriComponentNamespace %> .util.Grouper[sPath];
+							var vGroup = <%= fioriComponentNamespace %>.util.Grouper[sPath];
 							aSorters.push(new sap.ui.model.Sorter(sPath, bDescending, vGroup));
 						}
 						var oBinding = that.getView().byId("list").getBinding("items");
@@ -69,9 +71,9 @@
 				});
 			}
 
-			// open dialog
 			this._lineItemViewDialog.open();
 		}
+
 	});
 
 }());

--- a/app/templates/fiori_application/view/_Root.controller.js
+++ b/app/templates/fiori_application/view/_Root.controller.js
@@ -4,38 +4,24 @@
 	sap.ui.controller("<%= fioriComponentNamespace %>.view.Root", {
 
 		onInit: function() {
+			var bus = sap.ui.getCore().getEventBus();
 
-			this.oRoot = this.getView().byId("idRoot");
+			bus.subscribe("nav", "to", this.navToHandler, this);
+			bus.subscribe("nav", "back", this.navBackHandler, this);
 
-			// Have child views use this controller for navigation
-			var that = this;
-			this.oRoot.getMasterPages().forEach(function(oPage) {
-				oPage.getController().navigation = that;
-			});
-
-			this.oRoot.getDetailPages().forEach(function(oPage) {
-				if (oPage.getId() !== "idViewRoot--idViewEmpty") {
-					oPage.getController().navigation = that;
-				}
-			});
-
+			this.app = this.getView().byId("idApp");
 		},
 
-
-		navTo: function(sPageId, oContext) {
-
-			this.oRoot.to(sPageId);
-			if (oContext) {
-				this.oRoot.getPage(sPageId).setBindingContext(oContext);
+		navToHandler: function(channelId, eventId, data) {
+			//data.id holds the page id
+			this.app.to(data.id);
+			if (data.data.context) {
+				this.app.getPage(data.id).setBindingContext(data.data.context);
 			}
-
 		},
 
-
-		navBack: function() {
-
-			this.oRoot.backDetail();
-
+		navBackHandler: function() {
+			this.app.backDetail();
 		}
 
 	});

--- a/app/templates/fiori_application/view/_Root.view.xml
+++ b/app/templates/fiori_application/view/_Root.view.xml
@@ -9,7 +9,7 @@
 	xmlns="sap.m">
 
 	<Shell showLogout="false">
-		<SplitApp id="idRoot">
+		<SplitApp id="idApp">
 			<masterPages>
 				<mvc:XMLView viewName="<%= fioriComponentNamespace %>.view.Master" id="idViewMaster" />
 			</masterPages>

--- a/app/templates/fiori_tiles_app/_Component.js
+++ b/app/templates/fiori_tiles_app/_Component.js
@@ -19,7 +19,6 @@ Component details:
 	sap.ui.core.UIComponent.extend("<%= fioriComponentNamespace %>.Component", {
 
 		createContent: function() {
-
 			// create root view
 			var oView = sap.ui.view({
 				id: "idViewRoot",
@@ -46,9 +45,7 @@ Component details:
 			deviceModel.setDefaultBindingMode("OneWay");
 			oView.setModel(deviceModel, "device");
 
-			// done
 			return oView;
-
 		}
 	});
 

--- a/app/templates/fiori_tiles_app/view/_Detail.controller.js
+++ b/app/templates/fiori_tiles_app/view/_Detail.controller.js
@@ -6,8 +6,12 @@
 
 	sap.ui.controller("<%= fioriComponentNamespace %>.view.Detail", {
 
+		onInit: function() {
+			this.bus = sap.ui.getCore().getEventBus();
+		},
+		
 		handleNavButtonPress: function() {
-			this.navigation.navBack();
+			this.bus.publish("nav", "back");
 		}
 		
 	});

--- a/app/templates/fiori_tiles_app/view/_Home.controller.js
+++ b/app/templates/fiori_tiles_app/view/_Home.controller.js
@@ -3,8 +3,17 @@
 
 	sap.ui.controller("<%= fioriComponentNamespace %>.view.Home", {
 
+		onInit: function() {
+			this.bus = sap.ui.getCore().getEventBus();
+		},
+
 		handleTileTap: function(evt) {
-			this.navigation.navTo("idViewRoot--idViewDetail", evt.getSource().getBindingContext());
+			this.bus.publish("nav", "to", {
+				id: "idViewRoot--idViewDetail",
+				data: {
+					context: evt.getSource().getBindingContext()
+				}
+			});
 		},
 
 		productCount: function(oValue) {

--- a/app/templates/fiori_tiles_app/view/_Root.controller.js
+++ b/app/templates/fiori_tiles_app/view/_Root.controller.js
@@ -3,24 +3,24 @@
 
 	sap.ui.controller("<%= fioriComponentNamespace %>.view.Root", {
 		onInit: function() {
-			this.app = this.getView().byId("idApp");
+			var bus = sap.ui.getCore().getEventBus();
 
-			// Have child views use this controller for navigation
-			var that = this;
-			this.app.getPages().forEach(function(page) {
-				page.getController().navigation = that;
-			});
+			bus.subscribe("nav", "to", this.navToHandler, this);
+			bus.subscribe("nav", "back", this.navBackHandler, this);
+
+			this.app = this.getView().byId("idApp");
 		},
 
-		navTo: function(pageId, context) {
-			this.app.to(pageId);
-			if (context) {
-				this.app.getPage(pageId).setBindingContext(context);
+		navToHandler: function(channelId, eventId, data) {
+			//data.id holds the page id
+			this.app.to(data.id);
+			if (data.data.context) {
+				this.app.getPage(data.id).setBindingContext(data.data.context);
 			}
 
 		},
 
-		navBack: function() {
+		navBackHandler: function() {
 			this.app.back();
 		}
 


### PR DESCRIPTION
Refactor the fiori-style apps (Splitter, Tiles) to use the EventBus for navigation instead of coupling all the page view controllers to the root controller.
Whether this really simplifies your app or not is a matter of personal preference, but it is the best-practice according to the current UI5 SDK: https://openui5.hana.ondemand.com/#docs/guide/BestPractice.html.

Also includes minor adjustments to standardise the use of whitespace.

Fixes #50
