### PR TITLE
fix(rewrite): Handle formatting of json comments when adding new resourc...

### DIFF
--- a/script-base.js
+++ b/script-base.js
@@ -208,12 +208,9 @@
 	 * @param {String} elementPath Path of the element to be checked
 	 */
 	Generator.prototype.addResourceRoot = function(elementPath) {
-		var indexPath = path.join(process.cwd(), "index.html");
-
-		//"foo.bar.MyComponent": "./foo/bar/MyComponent"
-		var resourcePath = elementPath.replace(/\./g, "/");
-		//var resourceRoot = ", \"" + elementPath + "\": \"" + resourcePath + "\"";
-		var resourceRoot = "\"" + elementPath + "\": \"" + resourcePath + "\"";
+		var //indexPath = path.join(process.cwd(), "index.html"),
+			resourcePath = elementPath.replace(/\./g, "/"),
+			resourceRoot = "\"" + elementPath + "\": \"" + resourcePath + "\"";
 
 		try {
 			console.log(chalk.green("    check ") + "resource root registered in UI5 bootstrap in index.html.");
@@ -223,18 +220,14 @@
 				splicable: [resourceRoot],
 				extraIndents: 1
 			});
-		} catch (e) {
-			if (e.name === "not_found") {
-				console.log(chalk.red("Unable to add component namespace as application resource root. Could not find identifier /* endOfResourceroots */"));
-			} else {
-				console.log(chalk.red("\nUnable to find " + indexPath + ". ") + chalk.yellow(resourceRoot) + " could not be registered. Please check the resource register manaually.\n");
-			}
-		}
 
-		openUI5Utils.addCommaToLine({
-			file: "index.html",
-			needle: "/* endOfResourceroots */",
-			offset: -2
-		});
+			openUI5Utils.addCommaToLine({
+				file: "index.html",
+				needle: "/* endOfResourceroots */",
+				offset: -2
+			});
+		} catch (e) {
+			openUI5Utils.logResourceRootEditingError(e);
+		}
 	};
 }());


### PR DESCRIPTION
...e roots

Add new method addCommaToLine(args) which allows you to find a line in a file
 and add a terminating comment char at a specified offset from that line. Uses
 same methods as in rewrite(args).
This solves the issue where new resource roots required a comma at the beginning of the line which did not look pretty.

Fixes #55 #57

This works great when using a clever editor like sublime, but if you're a poor sole that uses NotePad then there is still an issue with windows carriage returns in rewrite() that I don't have time to get to the bottom now... I think we should just leave it - and maybe even remove all concerns about windows carriage returns. i.e. ignore doing this: `lines[otherwiseLineIndex] += "\r";` No harm in having it in there though.
