### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/COMMIT_GUIDELINES.md
+++ b/COMMIT_GUIDELINES.md
@@ -41,11 +41,11 @@ The subject contains succinct description of the change:
 * don't capitalize first letter
 * no dot (.) at the end
 
-###Body
+### Body
 Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes"
 The body should include the motivation for the change and contrast this with previous behavior.
 
-###Footer
+### Footer
 The footer should contain any information about **Breaking Changes** and is also the place to
 reference GitHub issues that this commit **Closes**.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Especially in Fiori like apps one often has an application namespace set in the 
 
 That is exactly what happens, when you choose _yes_ as an answer for the above question. The generator tries to assemble the current application namespace and adds that to the component name (same for views). For sure, you have to possibility to change that name before it's finally generated.
 
-##TDG Best Practices App
+## TDG Best Practices App
 When generating the ```TDG Best Practices App``` please note that you should add the query parameter ```?responderOn=true``` to your local testing url. This allows you to use the mock data.
 
 ## Offline


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
